### PR TITLE
Do not merge concentric colliders with different widths

### DIFF
--- a/TilemapCollisionBaker.gd
+++ b/TilemapCollisionBaker.gd
@@ -112,7 +112,7 @@ func run_code(_fake_bool = null):
 			continue
 		
 		var tile_y_distance = abs(temp_collider.position.y - last_collider_pos.y) / tile_size.y
-		if last_collider_pos.x == temp_collider.position.x and tile_y_distance == 1:
+		if last_collider_pos.x == temp_collider.position.x and tile_y_distance == 1 and temp_collider.shape.size.x == last_collider.shape.size.x:
 			#print("Adding 1 to the merge")
 			colliders_to_merge += 1
 			last_collider_pos = temp_collider.position


### PR DESCRIPTION
# Summary
This is a bug fix for incorrect behaviour in the merging code. Adjacent colliders that have the same X coordinate are merged regardless of their size. This produces incorrect results when you have "rows" of tiles that are at the same position:

![image](https://github.com/user-attachments/assets/2899a9b6-4916-4ef4-abbb-51cf7ccbb42b)

This adds a simple check to ONLY merge if the colliders are also the same width:

![image](https://github.com/user-attachments/assets/83038251-59db-48b8-bdb0-c96d09cef108)

I haven't extensively tested this so I can't say for sure whether this will produce new bugs. However, if the collider is being naively merged anyway, it stands to reason that any bugs that exist now would have existed prior. 

Thanks for making this script!