### PR TITLE
Migrate from deprecated TileMap node to TileMapLayer node

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 Godot Tilemap Baker is a tool to easily pre-bake collisions on square tilemaps. This can be useful for many reasons, the biggest one being that using the [default tileset collision can cause issues with rigidbodies](https://github.com/godotengine/godot/issues/72372) because objects tend to get stuck in-between tiles. TilemapBaker was built with this in mind, so floors and ceilings are always one smooth rectangle collider. It should also ^theoretically be more optimized because you end up with way less colliders.
 
 ## How to use
-Simply attach the `TilemapCollisionBaker` script to an empty StaticBody2D, then point to your Tilemap in the inspector, and hit "Run Script". This is going to wrap your tileset with large box colliders, to be added as children to this node.
+Simply attach the `TilemapCollisionBaker` script to an empty StaticBody2D, then point to your Tilemap Layer in the inspector, and hit "Run Script". This is going to wrap your tileset with large box colliders, to be added as children to this node.
 
 You can also select a specific tile layer to bake collisions for, which can be useful if you have slopes or water on separate layers for example.
 

--- a/TilemapCollisionBaker.gd
+++ b/TilemapCollisionBaker.gd
@@ -26,7 +26,7 @@ extends StaticBody2D
 @export var run_script: bool = false : set = run_code
 
 func run_code(_fake_bool = null):
-	var tile_map: TileMap = get_node(tilemap_nodepath)
+	var tile_map: TileMapLayer = get_node(tilemap_nodepath)
 	if tile_map == null:
 		print("Hey, you forgot to set your Tilemap Nodepath.")
 		return
@@ -35,7 +35,7 @@ func run_code(_fake_bool = null):
 		delete_children()
 	
 	var tile_size = tile_map.tile_set.tile_size
-	var tilemap_locations = tile_map.get_used_cells(target_tiles_layer)
+	var tilemap_locations = tile_map.get_used_cells()
 	
 	if tilemap_locations.size() == 0:
 		print("Hey, this tilemap is empty (did you choose the correct layer?)")

--- a/TilemapCollisionBaker.gd
+++ b/TilemapCollisionBaker.gd
@@ -28,7 +28,7 @@ extends StaticBody2D
 func run_code(_fake_bool = null):
 	var tile_map: TileMapLayer = get_node(tilemap_nodepath)
 	if tile_map == null:
-		print("Hey, you forgot to set your Tilemap Nodepath.")
+		print("Hey, you forgot to set your Tilemap Layer Nodepath.")
 		return
 	
 	if delete_children_on_run:
@@ -38,7 +38,7 @@ func run_code(_fake_bool = null):
 	var tilemap_locations = tile_map.get_used_cells()
 	
 	if tilemap_locations.size() == 0:
-		print("Hey, this tilemap is empty (did you choose the correct layer?)")
+		print("Hey, this tilemap layer is empty!")
 		return
 	
 	# I use .pop_back() to go through the array, so I sort them from bottom right to top left.


### PR DESCRIPTION
Fix for #5, which updates the script to work with the new TileMapLayer nodes instead of the deprecated TileMap nodes.